### PR TITLE
fix variance computing method

### DIFF
--- a/src/statistics/sampleVariance.js
+++ b/src/statistics/sampleVariance.js
@@ -27,7 +27,7 @@ define(function (require) {
                     sum += temple * temple;
                 }
             }
-            return sum / data.length - 1;
+            return sum / (data.length - 1);
         }
     }
 


### PR DESCRIPTION
missing brackets , and division will be run first ,and get wrong answer
缺括号导致运算顺序出错