### PR TITLE
fix tickStep's precision

### DIFF
--- a/src/util/tickStep.js
+++ b/src/util/tickStep.js
@@ -23,7 +23,7 @@ define(function (require) {
         else if(error >= Math.sqrt(2)) {
             step1 *= 2;
         }
-        return +((stop >= start ? step1 : -step1).toFixed(-precision));
+        return +((stop >= start ? step1 : -step1).toFixed(precision));
 
     };
 


### PR DESCRIPTION
precision must be a positive number, argument in methods toFix() should be positive. see issue 16: https://github.com/ecomfe/echarts-stat/issues/16